### PR TITLE
Added pkexec support

### DIFF
--- a/apturl
+++ b/apturl
@@ -1,3 +1,16 @@
-#!/bin/sh
+#!/usr/bin/python3
 
-apturl-gtk $@
+import os
+import subprocess
+import sys
+
+def get_output_uni(*args):  # uni = Unicode 
+  return subprocess.check_output(*args, universal_newlines=True).rstrip()
+# We set "universal_newlines" in order to handle Unicode properly.  
+
+launcher = get_output_uni("/usr/lib/linuxmint/common/mint-which-launcher.py")
+target = "apturl-gtk"
+params = " ".join(sys.argv[1:])
+
+command_string = "{0} {1} {2}".format(launcher, target, params)
+os.system(command_string)

--- a/data/com.linuxmint.apturl-gtk.policy.in
+++ b/data/com.linuxmint.apturl-gtk.policy.in
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC 
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" 
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>Linux Mint</vendor>
+  <vendor_url>https://linuxmint.com/</vendor_url>
+
+  <action id="com.linuxmint.apturl-gtk">
+    <_description>'apturl' authentication dialog</_description>
+    <_message>Please enter your password to run the 'apturl' package installer</_message>
+    <icon_name>synaptic</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/apturl-gtk</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+
+</policyconfig>

--- a/debian/apturl-common.install
+++ b/debian/apturl-common.install
@@ -5,3 +5,4 @@ usr/lib/python3/*-packages/apturl-*.egg-info
 usr/share/kde4/services
 usr/share/locale
 usr/share/applications
+usr/share/polkit-1/actions

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [build_i18n]
 domain=apturl
-schemas_files=[("share/gconf/schemas", ("data/apturl.schemas.in",))]
+schemas_files=[("share/gconf/schemas", ("data/apturl.schemas.in",)), 
+               ("share/polkit-1/actions", ("data/com.linuxmint.apturl-gtk.policy.in",))]


### PR DESCRIPTION
See https://github.com/linuxmint/mintsources/issues/75

`apturl` is launched by the global apps menu's "Install Multimedia Codecs" icon.  